### PR TITLE
Fix persistence of encrypted notes

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -23,20 +23,15 @@ func CreateNote(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	payload, _ := ioutil.ReadAll(r.Body)
 	note := database.Note{}
 	json.Unmarshal(payload, &note)
-	note, err := database.Create(note)
-
-	// Return the note (minus the content) in case the UI sees any
-	// changes (like timestamps or ids for new notes)
-	note.Content = ""
+	_, err := database.Create(note)
 	if err != nil {
 		fmt.Fprintf(w, err.Error())
 	}
-	noteJSON, err := json.MarshalIndent(note, "", "  ")
+	noteJSON, err := note.ToJSON()
 	if err != nil {
-		log.Error("Failed to parse note into json", err)
 		fmt.Fprintf(w, err.Error())
 	}
-	fmt.Fprintf(w, string(noteJSON))
+	fmt.Fprintf(w, noteJSON)
 }
 
 // DeleteNote removes a note from storage
@@ -88,14 +83,9 @@ func UpdateNote(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	if err != nil {
 		fmt.Fprintf(w, err.Error())
 	}
-
-	// Return the note (minus the content) in case the UI sees any
-	// changes (like timestamps or ids for new notes)
-	note.Content = ""
-	noteJSON, err := json.MarshalIndent(note, "", "  ")
+	noteJSON, err := note.ToJSON()
 	if err != nil {
-		log.Error("Failed to parse note into json", err)
 		fmt.Fprintf(w, err.Error())
 	}
-	fmt.Fprintf(w, string(noteJSON))
+	fmt.Fprintf(w, noteJSON)
 }


### PR DESCRIPTION
The first problem was that the Encrypted field was not being set or
unset as needed. Additionally the Password field was excluded from
JSON parsing, so ultimately was not being consumed. This resulted in
encrypted notes being persisted in plain text (no password) but still
being flagged as being encrypted. In order to ensure the desired bits
are excluded from being sent back to the frontend a ToJSON method was
added to encapsulate this logic.