### PR TITLE
Simplify the search widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.0.3 / ...
 
 * Fix initial subject focus on note creation.
+* Improve search performance by simplifying the widget.
 
 ## v0.0.2 / 2017-03-10
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -11,14 +11,6 @@
 .editor {
   margin-top: 12px;
 }
-
-.form-inline.search input {
-  position: relative;
-  right: -450px;
-  width: 400px;
-  padding: 2px;
-}
-
 .note-row:hover {
   cursor: pointer;
 }
@@ -27,12 +19,8 @@
   margin-top: -4px
 }
 
-.search-container {
-  overflow: hidden;
-  position: absolute;
-  right: 85px;
-  top: 4px;
-  width: 400px;
+#search {
+  margin-right: 6px;
 }
 
 .table {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -42,7 +42,9 @@ require(
       collection: new NotesCollection(),
       el: $('#notes'),
       passwordModal: new PasswordModalView(),
-      searchModal: new SearchModalView()
+      searchModal: new SearchModalView({
+        el: $('#search'),
+      }).render()
     });
 	}
 );

--- a/static/js/views/search.js
+++ b/static/js/views/search.js
@@ -11,17 +11,13 @@ function(searchTemplate, Mousetrap) {
   return Backbone.View.extend({
 
     events: {
-      'keyup .search-query': 'search',
+      'keyup #search': 'search',
       'submit form': 'noop'
     },
 
     hide: function() {
       this.trigger('search', null);
-      this.$('input').animate({
-        right: '-450px'
-      }, 'fast', function() {
-        $(this).val('').blur();
-      });
+      this.$('input').blur();
     },
 
     initialize: function() {
@@ -60,12 +56,9 @@ function(searchTemplate, Mousetrap) {
     },
 
     show: function() {
+      this.$('input').focus();
       $('.nav-tabs a:first').tab('show');
-      this.$('input').animate({
-        right: '0px'
-      }, 'fast', function() {
-        $(this).focus();
-      });
+      return false
     },
 
     search: function() {

--- a/static/js/views/table.js
+++ b/static/js/views/table.js
@@ -23,7 +23,6 @@ function(Backbone,
       this.collection.on('reset', this.render, this);
       this.collection.fetch();
       $('body').append(this.options.passwordModal.render().el);
-      $('body').append(this.options.searchModal.render().el);
       $('.create').on('click', _.bind(this.createNote, this));
       Mousetrap.bind('ctrl+c', _.bind(this.createNote, this));
       Mousetrap.bind('j', _.bind(this.selectNextNote, this));

--- a/static/templates/index.html
+++ b/static/templates/index.html
@@ -14,6 +14,7 @@
       <div class="row">
         <div class="col-md-12">
           <button type="button" class="btn btn-default pull-right create">Create</button>
+          <div id="search"></div>
           <ul class="nav nav-tabs" role="tablist">
             <li class="active"><a href="#notes" data-toggle="tab">Notes</a></li>
           </ul>

--- a/static/templates/search.html
+++ b/static/templates/search.html
@@ -1,5 +1,4 @@
-<div class="search-container">
-  <form class="form-inline search" role="form">
-    <input type="text" class="input-medium search-query mousetrap" placeholder="Search..." />
-  </form>
+<div id="search" class="input-group pull-right col-md-3">
+  <div class="input-group-addon">Search</div>
+  <input class="form-control mousetrap" type="text" placeholder="Phrase or tag" />
 </div>


### PR DESCRIPTION
- Remove animations
- Remove custom css
- Use almost entirely vanilla bootstrap
- Dramatically improved performance. Previously there was a pretty high
  miss rate on the first character involved in the search.
- Stop nulling the search input after searching. This will make more
  sense when the note listing stops getting reset after search too.