### PR TITLE
Allow forward slashes on form inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.0.7 / ...
 
 * Allow search to be resumed after switching tabs.
+* Allow forward slashes in subject, tag, and password fields.
 
 ## v0.0.6 / 2017-03-23
 

--- a/static/js/views/search.js
+++ b/static/js/views/search.js
@@ -49,7 +49,12 @@ function(searchTemplate, Mousetrap) {
       return this;
     },
 
-    show: function() {
+    show: function(e) {
+      if (typeof document.activeElement.form != 'undefined') {
+        var el = $(e.target);
+        el.val(el.val() + e.key);
+        return false;
+      }
       this.focus();
       $('.nav-tabs a:first').tab('show');
       return false


### PR DESCRIPTION
Previously Mousetrap was intercepting the forward slash and invoking
search.