### PR TITLE
Toggle primary tab based on search focus, not keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.8 / ...
+
+* Allow search to be resumed after manual focus.
+
 ## v0.0.7 / 2017-03-29
 
 * Allow search to be resumed after switching tabs.

--- a/static/js/views/search.js
+++ b/static/js/views/search.js
@@ -12,12 +12,17 @@ function(searchTemplate, Mousetrap) {
 
     events: {
       'keyup #search': 'search',
-      'submit form': 'noop'
+      'submit form': 'noop',
+      'focus input': 'activatePrimaryTab'
     },
 
     initialize: function() {
       this._query = null;
       Mousetrap.bind('/', _.bind(this.show, this));
+    },
+
+    activatePrimaryTab: function() {
+      $('.nav-tabs a:first').tab('show');
     },
 
     focus: function() {
@@ -56,7 +61,6 @@ function(searchTemplate, Mousetrap) {
         return false;
       }
       this.focus();
-      $('.nav-tabs a:first').tab('show');
       return false
     },
 


### PR DESCRIPTION
Previously the primary tab would properly focus if the search keybinding
were pressed, but not if the user manually focused the search input.
This commit moves the tab activation to the focus event so it happens in
either case.