### PR TITLE
Use AES-GCM encryptiong going forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.1.2 / ...
 
 * Fix Docker tags on release (was not updating the docker.io tags)
+* Improve encryption by using AES-GCM [via cryptopasta](https://github.com/gtank/cryptopasta)
 
 ## v0.1.1 / 2017-10-29
 

--- a/app/deprecated_encryption.go
+++ b/app/deprecated_encryption.go
@@ -1,0 +1,80 @@
+package app
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"io"
+	"strings"
+)
+
+// Reference: https://golang.org/src/crypto/cipher/example_test.go
+
+var (
+	// Right side padding for CBC to make size uniform for encryption
+	padding = string(rune(0))
+	// Bits we're using 16bit IV and 32bit AES
+	bits = struct {
+		AES int
+		IV  int
+	}{32, 16}
+)
+
+// CBCDecrypt a string given the provided password
+func CBCDecrypt(content string, password string) (string, error) {
+	// Base64 decode the string
+	decoded, err := base64.StdEncoding.DecodeString(content)
+	if err != nil {
+		return "", err
+	}
+
+	// Extract the iv and the encrypted cipher
+	iv := decoded[:bits.IV]
+	payload := decoded[bits.IV:]
+
+	// Create the aes thingy
+	aesBlock, err := aes.NewCipher(passwordHash(password))
+	if err != nil {
+		return "", err
+	}
+
+	// Create the decryptor and decrypt payload with it
+	decrypter := cipher.NewCBCDecrypter(aesBlock, iv)
+	decrypter.CryptBlocks(payload, payload)
+
+	return strings.TrimRight(string(payload), padding), nil
+}
+
+// CBCEncrypt a string given the provided password
+func CBCEncrypt(content string, password string) (string, error) {
+	key := passwordHash(password)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	padded := pad(content)
+	ciphertext := make([]byte, aes.BlockSize+len(padded))
+	iv := ciphertext[:aes.BlockSize]
+	_, err = io.ReadFull(rand.Reader, iv)
+	if err != nil {
+		return "", err
+	}
+	mode := cipher.NewCBCEncrypter(block, iv)
+	mode.CryptBlocks(ciphertext[aes.BlockSize:], []byte(padded))
+	return base64.StdEncoding.EncodeToString(ciphertext), nil
+}
+
+// Pad with 32bits for AES
+func pad(content string) string {
+	return content + strings.Repeat(padding,
+		bits.AES-len(content)%bits.AES)
+}
+
+// Calculate the sha256 hash of a given password
+func passwordHash(password string) []byte {
+	hasher := sha256.New()
+	hasher.Write([]byte(password))
+	return hasher.Sum(nil)
+}

--- a/app/deprecated_encryption_test.go
+++ b/app/deprecated_encryption_test.go
@@ -21,19 +21,19 @@ var samplePasswords = []struct {
 	{"special_chars", `~!@#$%^&*()_+-={}[]\\|;':\",./<>?`},
 }
 
-func TestDecryptionReturnsOriginal(t *testing.T) {
+func TestCBCDecryptionReturnsOriginal(t *testing.T) {
 	for _, tt := range samplePasswords {
-		encrypted, err := Encrypt(original, tt.Password)
+		encrypted, err := CBCEncrypt(original, tt.Password)
 		assert.Nil(t, err, "Should not be an error calling encrypt")
-		decrypted, err := Decrypt(encrypted, tt.Password)
+		decrypted, err := CBCDecrypt(encrypted, tt.Password)
 		assert.Nil(t, err, "Should not be an error calling decrypt")
 		msg := fmt.Sprintf("Decryption should return the original (%s)", tt.Description)
 		assert.Equal(t, decrypted, original, msg)
 	}
 	password := "my secret password"
-	encrypted, err := Encrypt(original, password)
+	encrypted, err := CBCEncrypt(original, password)
 	assert.Nil(t, err, "Should not be an error calling encrypt")
-	decrypted, err := Decrypt(encrypted, password)
+	decrypted, err := CBCDecrypt(encrypted, password)
 	assert.Nil(t, err, "Should not be an error calling decrypt")
 	assert.Equal(t, decrypted, original, "Decryption should return the original")
 

--- a/app/encryption.go
+++ b/app/encryption.go
@@ -1,88 +1,14 @@
 package app
 
-import (
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/rand"
-	"crypto/sha256"
-	"encoding/base64"
-	"io"
-	"regexp"
-	"strings"
-)
-
-// Reference: https://golang.org/src/crypto/cipher/example_test.go
+import "regexp"
 
 var (
-	// Right side padding for CBC to make size uniform for encryption
-	padding = string(rune(0))
-	// Bits we're using 16bit IV and 32bit AES
-	bits = struct {
-		AES int
-		IV  int
-	}{32, 16}
 	// Decrypted strings generally look like this
 	decryptedRE = regexp.MustCompile(`[\x00-\x7F]`)
+
 	// Encrypted string generally look like this
 	encryptedRE = regexp.MustCompile(`[^\x00-\x7F]`)
 )
-
-// Decrypt a string given the provided password
-func Decrypt(content string, password string) (string, error) {
-	// Base64 decode the string
-	decoded, err := base64.StdEncoding.DecodeString(content)
-	if err != nil {
-		return "", err
-	}
-
-	// Extract the iv and the encrypted cipher
-	iv := decoded[:bits.IV]
-	payload := decoded[bits.IV:]
-
-	// Create the aes thingy
-	aesBlock, err := aes.NewCipher(passwordHash(password))
-	if err != nil {
-		return "", err
-	}
-
-	// Create the decryptor and decrypt payload with it
-	decrypter := cipher.NewCBCDecrypter(aesBlock, iv)
-	decrypter.CryptBlocks(payload, payload)
-
-	return strings.TrimRight(string(payload), padding), nil
-}
-
-// Encrypt a string given the provided password
-func Encrypt(content string, password string) (string, error) {
-	key := passwordHash(password)
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return "", err
-	}
-	padded := pad(content)
-	ciphertext := make([]byte, aes.BlockSize+len(padded))
-	iv := ciphertext[:aes.BlockSize]
-	_, err = io.ReadFull(rand.Reader, iv)
-	if err != nil {
-		return "", err
-	}
-	mode := cipher.NewCBCEncrypter(block, iv)
-	mode.CryptBlocks(ciphertext[aes.BlockSize:], []byte(padded))
-	return base64.StdEncoding.EncodeToString(ciphertext), nil
-}
-
-// Pad with 32bits for AES
-func pad(content string) string {
-	return content + strings.Repeat(padding,
-		bits.AES-len(content)%bits.AES)
-}
-
-// Calculate the sha256 hash of a given password
-func passwordHash(password string) []byte {
-	hasher := sha256.New()
-	hasher.Write([]byte(password))
-	return hasher.Sum(nil)
-}
 
 // SmellsEncrypted - Try to guess if a string is encrypted or not
 func SmellsEncrypted(content string) bool {

--- a/app/encryption.go
+++ b/app/encryption.go
@@ -1,6 +1,12 @@
 package app
 
-import "regexp"
+import (
+	"crypto/sha256"
+	"errors"
+	"regexp"
+
+	"github.com/gtank/cryptopasta"
+)
 
 var (
 	// Decrypted strings generally look like this
@@ -8,6 +14,11 @@ var (
 
 	// Encrypted string generally look like this
 	encryptedRE = regexp.MustCompile(`[^\x00-\x7F]`)
+)
+
+const (
+	aesCbc = "AES-CBC"
+	aesGcm = "AES-GCM"
 )
 
 // SmellsEncrypted - Try to guess if a string is encrypted or not
@@ -18,4 +29,24 @@ func SmellsEncrypted(content string) bool {
 		return true
 	}
 	return false
+}
+
+// Decrypt using the correct cipher type
+func Decrypt(note Note, password string) (string, error) {
+	if note.CipherType == aesGcm {
+		key := sha256.Sum256([]byte(password))
+		clearText, err := cryptopasta.Decrypt([]byte(note.Content), &key)
+		return string(clearText), err
+	}
+	return CBCDecrypt(note.Content, password)
+}
+
+// Encrypt a note using the currently desired mechanism: AES-GCM
+func Encrypt(note Note) (string, string, error) {
+	if note.Password == "" {
+		return "", "", errors.New("Cannot encrypt with an empty password")
+	}
+	key := sha256.Sum256([]byte(note.Password))
+	cipherText, err := cryptopasta.Encrypt([]byte(note.Content), &key)
+	return string(cipherText), aesGcm, err
 }

--- a/app/encryption_test.go
+++ b/app/encryption_test.go
@@ -1,0 +1,32 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultEncryption(t *testing.T) {
+	password := "my secret password"
+	content := "Some beer pls"
+	note := Note{Content: content, Password: password}
+	cipherText, cipherType, err := Encrypt(note)
+	assert.Nil(t, err, "Should not be an error calling encrypt")
+	assert.Equal(t, cipherType, "AES-GCM", "Default encryption type is wrong")
+	note.CipherType = cipherType
+	note.Content = cipherText
+	decrypted, err := Decrypt(note, password)
+	assert.Nil(t, err, "Should not be an error calling decrypt")
+	assert.Equal(t, decrypted, content, "Decryption should return the original")
+}
+
+func TestDecryptionOfDeprecatedCBC(t *testing.T) {
+	password := "my secret password"
+	content := "Some beer pls"
+	encrypted, err := CBCEncrypt(content, password)
+	assert.Nil(t, err, "Should not be an error calling encrypt")
+	note := Note{Content: encrypted, Encrypted: true}
+	decrypted, err := Decrypt(note, password)
+	assert.Nil(t, err, "Should not be an error calling decrypt")
+	assert.Equal(t, decrypted, content, "Decryption should return the original")
+}

--- a/app/model.go
+++ b/app/model.go
@@ -34,6 +34,7 @@ type Note struct {
 	Time           time.Time `json:"time"`
 
 	// Private fields
+	CipherType    string `json:"-"`
 	SecondaryPath string `json:"-"`
 }
 
@@ -106,11 +107,12 @@ func Persistable(note Note) (Note, error) {
 	}
 	// Make sure the contents are encrypted if a password is set
 	if note.Password != "" {
-		encrypted, err := CBCEncrypt(note.Content, note.Password)
+		ciperText, cipherType, err := Encrypt(note)
 		if err != nil {
 			return note, err
 		}
-		note.Content = encrypted
+		note.CipherType = cipherType
+		note.Content = ciperText
 		note.Encrypted = true
 	} else {
 		note.Encrypted = false

--- a/app/model.go
+++ b/app/model.go
@@ -106,7 +106,7 @@ func Persistable(note Note) (Note, error) {
 	}
 	// Make sure the contents are encrypted if a password is set
 	if note.Password != "" {
-		encrypted, err := Encrypt(note.Content, note.Password)
+		encrypted, err := CBCEncrypt(note.Content, note.Password)
 		if err != nil {
 			return note, err
 		}

--- a/backend.go
+++ b/backend.go
@@ -38,7 +38,7 @@ type Backend interface {
 
 func decryptNote(note app.Note, password string) (app.Note, error) {
 	if password != "" {
-		decrypted, err := app.Decrypt(note.Content, password)
+		decrypted, err := app.CBCDecrypt(note.Content, password)
 		if err != nil {
 			return note, err
 		}

--- a/backend.go
+++ b/backend.go
@@ -38,11 +38,11 @@ type Backend interface {
 
 func decryptNote(note app.Note, password string) (app.Note, error) {
 	if password != "" {
-		decrypted, err := app.CBCDecrypt(note.Content, password)
+		clearText, err := app.Decrypt(note, password)
 		if err != nil {
 			return note, err
 		}
-		note.Content = decrypted
+		note.Content = clearText
 	}
 	return note, nil
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fea1d9c32c4ec7b6d96ab3b4e4efcea518949e5dda144ec8459af51b8a0b11c0
-updated: 2017-09-18T21:17:35.187709029-07:00
+hash: a3e6845de82fb73249c27f5ee19a657d174a8ec1aaf11072d86b12218b0ef955
+updated: 2017-10-31T03:33:29.669973698-07:00
 imports:
 - name: github.com/blevesearch/bleve
   version: 5c9915c6f41b05317744a2ec0340a2f71973025a
@@ -55,6 +55,8 @@ imports:
   repo: https://github.com/golang/protobuf
   subpackages:
   - proto
+- name: github.com/gtank/cryptopasta
+  version: 1f550f6f2f69009f6ae57347c188e0a67cd4e500
 - name: github.com/hashicorp/hcl
   version: a4b07c25de5ff55ad3b8936cea69a79a3d95a855
   subpackages:
@@ -112,6 +114,7 @@ imports:
   repo: https://go.googlesource.com/net
   subpackages:
   - context
+  - websocket
 - name: golang.org/x/sys
   version: 9ccfe848b9db8435a24c424abbc07a921adf1df5
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: a3e6845de82fb73249c27f5ee19a657d174a8ec1aaf11072d86b12218b0ef955
-updated: 2017-10-31T03:33:29.669973698-07:00
+hash: 04aa9a11a73503d2ac56d6e493102be399cc9e794837b33b7141dff08b56384b
+updated: 2017-10-31T17:22:31.553892435-07:00
 imports:
 - name: github.com/blevesearch/bleve
-  version: 5c9915c6f41b05317744a2ec0340a2f71973025a
+  version: 6eea5b78da004393b1d06b8c88d1bed9ca0a94b2
   subpackages:
   - analysis
   - analysis/analyzer/standard
@@ -41,7 +41,7 @@ imports:
   version: db70c57796cc8c310613541dfade3dce627d09c7
   repo: https://github.com/blevesearch/segment
 - name: github.com/boltdb/bolt
-  version: e9cf4fae01b5a8ff89d0ec6b32f0d9c9f79aefdd
+  version: fa5367d20c994db73282594be0146ab221657943
 - name: github.com/drhodes/golorem
   version: ecccc744c2d953a1e13cbe5e5fc5d4cbc9b8daeb
 - name: github.com/elazarl/go-bindata-assetfs
@@ -75,7 +75,7 @@ imports:
   subpackages:
   - '...'
 - name: github.com/julienschmidt/httprouter
-  version: 975b5c4c7c21c0e3d2764200bf2aa8e34657ae6e
+  version: e1b9828bc9e5904baec057a154c09ca40fe7fae0
 - name: github.com/magiconair/properties
   version: 51463bfca2576e06c62a8504b5c0f06d61312647
 - name: github.com/mitchellh/go-homedir
@@ -87,9 +87,9 @@ imports:
 - name: github.com/pelletier/go-toml
   version: 23f644976aa7c724adf4aec911dadf4af17840ab
 - name: github.com/pkg/errors
-  version: c605e284fe17294bda444b34710735b29d1a9d90
+  version: f15c970de5b76fac0b59abb32d62c17cc7bed265
 - name: github.com/sirupsen/logrus
-  version: acfabf31db8f45a9174f54a0d48ea4d15627af4d
+  version: 89742aefa4b206dcf400792f3bd35b542998eb3b
 - name: github.com/spf13/afero
   version: 9be650865eab0c12963d8753212f4f9c66cdcf12
   subpackages:
@@ -109,6 +109,12 @@ imports:
   repo: https://github.com/steveyen/gtreap
 - name: github.com/twinj/uuid
   version: 7bbe408d339787c56ec15568c947c0959db1b275
+- name: golang.org/x/crypto
+  version: bd6f299fb381e4c3393d1c4b1f0b94f5e77650c8
+  subpackages:
+  - bcrypt
+  - blowfish
+  - ssh/terminal
 - name: golang.org/x/net
   version: e45385e9b226f570b1f086bf287b25d3d4117776
   repo: https://go.googlesource.com/net
@@ -119,6 +125,7 @@ imports:
   version: 9ccfe848b9db8435a24c424abbc07a921adf1df5
   subpackages:
   - unix
+  - windows
 - name: golang.org/x/text
   version: 5ee49cfe751141f8017047bab800d1f528ee3be1
   repo: https://go.googlesource.com/text
@@ -137,6 +144,6 @@ testImports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
+  version: 2aa2c176b9dab406a6970f6a55f513e8a8c8b18f
   subpackages:
   - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,6 +25,9 @@ import:
   subpackages:
   - '...'
 - package: github.com/gtank/cryptopasta
+- package: golang.org/x/crypto
+  subpackages:
+  - bcrypt
 testImport:
 - package: github.com/stretchr/testify
   version: master

--- a/glide.yaml
+++ b/glide.yaml
@@ -24,6 +24,7 @@ import:
   version: master
   subpackages:
   - '...'
+- package: github.com/gtank/cryptopasta
 testImport:
 - package: github.com/stretchr/testify
   version: master

--- a/handlers.go
+++ b/handlers.go
@@ -55,14 +55,10 @@ func deleteNote(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 func getContent(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	password := r.PostFormValue("password")
 	content, err := getContentByUID(db, ps.ByName("uid"), password)
-	if app.SmellsEncrypted(content) == true {
+	if err != nil || app.SmellsEncrypted(content) == true {
 		w.WriteHeader(http.StatusForbidden)
 		fmt.Fprintf(w, "Nope, try again")
 		return
-	}
-	if err != nil {
-		log.Error(err)
-		fmt.Fprintf(w, "ERROR")
 	}
 	w.Write([]byte(content))
 }


### PR DESCRIPTION
This is backwards compatible, and migrates notes to better encryption as each one gets updated.

Thanks @drymonsoon, am fixing this due to #63 being stale